### PR TITLE
Support of protocol v1 (draft 01).

### DIFF
--- a/bmp.lua
+++ b/bmp.lua
@@ -186,8 +186,8 @@ function bmp_proto.dissector(buf, pinfo, tree)
         local _type_range = _version > 1 and buf(offset+5,1) or buf(offset+1,1)
         local _type = _type_range:uint()
 
-		local _length_range = _version > 1 and buf(offset+1,4) 
-		local _length = _version > 1 and _length_range:uint() or pdu_v1_length(_type, buf, offset)
+        local _length_range = _version > 1 and buf(offset+1,4) 
+        local _length = _version > 1 and _length_range:uint() or pdu_v1_length(_type, buf, offset)
 
         if _length == nil then
             pinfo.desegment_offset = offset
@@ -249,7 +249,6 @@ end
 
 function pdu_v1_length(type, buf, offset) 
     local bmp_payload_offset = offset + BMPv1_HEADER_LEN
-
 
     if bmp_type[type] == "Route Monitoring" then
         if bmp_payload_offset + BGP_MARKER_LEN + 2 > buf:len() then return nil end


### PR DESCRIPTION
Hi! Thanks a lot for this dissector. It's been published at just the right time for me. Alas some of routers in our infrastructure are old Junipers with obsolete version of bmp. So I have modified code of dissection for the sake of support the appropriate version as described in https://tools.ietf.org/html/draft-ietf-grow-bmp-01. 

The basic addition is a tricky function `pdu_v1_length()` and checking of version of protocol at some places. I also modified the main loop of `bmp_proto.dissector(buf, pinfo, tree)` - seems like a tcp segment may split a bmp message between `Version` and `Msg. Type` or `Length` fields, so we should guarantee that buf have enough space before operation. 

It works fine with wireshark 1.12.0 and 1.12.3. With tshark dissector in some way duplicates records (checked thru run `tshark   -r /tmp/f24.pcap -Tfields  -e bgp.length`) . This issue can be fixed by running with the key `-2   perform a two-pass analysis` . I don't know why duplication occures - the documentation of pinfo and DESEGMENT_ONE_MORE_SEGMENT is not good enough.
